### PR TITLE
Add Makefile to simplify build instructions

### DIFF
--- a/.github/workflows/ci-cmake-build-develop.yml
+++ b/.github/workflows/ci-cmake-build-develop.yml
@@ -1,4 +1,4 @@
-name: CMake Build - Develop
+name: Ubuntu-18.04 - Develop
 
 on:
   push:

--- a/.github/workflows/ci-cmake-build-master.yml
+++ b/.github/workflows/ci-cmake-build-master.yml
@@ -1,4 +1,4 @@
-name: CMake Build - Master
+name: Ubuntu-18.04
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ CMakeCache.txt
 CMakeFiles
 CMakeScripts
 Testing
-Makefile
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: docker-build
+docker-build:
+		docker build . -t membot && \
+		open -a XQuartz && \
+		ip=$$(ifconfig en0 | grep inet | awk '$$1=="inet" {print $$2}') && \
+		xhost + $$ip && \
+		docker run -it --rm --name membot -e DISPLAY=$$ip:0 -v /tmp/.X11-unix:/tmp/.X11-unix membot:latest

--- a/README.md
+++ b/README.md
@@ -12,14 +12,9 @@ This project is also an exercise in implementing RAII from scratch for objects a
 
 ### Dependencies for Running Locally
 * [Docker](https://docs.docker.com/get-docker/) for Mac
-* [xQuartz 2.7.10](https://www.xquartz.org/releases/XQuartz-2.7.10.html) for Mac (2.7.11 does not work with Docker)
+* [xQuartz 2.7.10](https://www.xquartz.org/releases/XQuartz-2.7.10.html) for Mac (>=2.7.11 does not work with Docker)
 
 ### Basic Build Instructions (with Docker)
 
-1. Clone this repo.
-2. `cd memory-mangement-chatbot`
-3. `docker build . -t membot`
-4. `open -a XQuartz` and go to Preferences (`CMD + ,`) and ensure the "Allow connections from network clients" is turned on (see [this](https://fredrikaverpil.github.io/2016/07/31/docker-for-mac-and-gui-applications/) article for help)
-5. `ip=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')`
-6. `xhost + $ip`
-4. `docker run -it --rm --name membot -e DISPLAY=$ip:0 -v /tmp/.X11-unix:/tmp/.X11-unix membot:latest`
+1. Clone this repo and `cd`  in to it.
+2. Build with Docker (only MacOS tested): `make docker-build`


### PR DESCRIPTION
**Main change**
Added a `Makefile` to simplify build instructions for local development on MacOS to just `make docker-build`.

**Additional changes**
- Removed `Makefile` from `.gitignore` to enable staging and addition of file
- Renamed both Github Action workflows to `Ubuntu-18.04` and `Ubuntu-18.04 Develop` to be more explicit in what the test is
- Updated `README.md` to reflect the changes to the build instructions utilizing the new one-liner instruction set