### PR TITLE
Add unique ownership to ChatBotPanelDialog object in chatgui.h

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y
 # general dependencies
 RUN apt-get install -y apt-transport-https ca-certificates gnupg \
     software-properties-common wget
-RUN apt-get install -y python3-pip
+RUN apt-get update && apt-get install -y python3-pip
 
 # upgrade CMake
 RUN apt-get remove cmake
@@ -30,6 +30,7 @@ RUN mkdir build
 WORKDIR /memory-management-chatbot/build
 RUN cmake ..
 RUN make
+
 
 # run binary on startup
 ENTRYPOINT [ "./membot" ]

--- a/src/chatgui.cpp
+++ b/src/chatgui.cpp
@@ -2,7 +2,6 @@
 #include <wx/colour.h>
 #include <wx/image.h>
 #include <string>
-#include <memory>
 #include "chatbot.h"
 #include "chatlogic.h"
 #include "chatgui.h"

--- a/src/chatgui.cpp
+++ b/src/chatgui.cpp
@@ -2,6 +2,7 @@
 #include <wx/colour.h>
 #include <wx/image.h>
 #include <string>
+#include <memory>
 #include "chatbot.h"
 #include "chatlogic.h"
 #include "chatgui.h"
@@ -118,7 +119,7 @@ ChatBotPanelDialog::ChatBotPanelDialog(wxWindow *parent, wxWindowID id)
     ////
 
     // create chat logic instance
-    _chatLogic = new ChatLogic(); 
+    _chatLogic = std::make_unique<ChatLogic>(ChatLogic());
 
     // pass pointer to chatbot dialog so answers can be displayed in GUI
     _chatLogic->SetPanelDialogHandle(this);
@@ -130,16 +131,16 @@ ChatBotPanelDialog::ChatBotPanelDialog(wxWindow *parent, wxWindowID id)
     //// EOF STUDENT CODE
 }
 
-ChatBotPanelDialog::~ChatBotPanelDialog()
-{
-    //// STUDENT CODE
-    ////
-
-    delete _chatLogic;
-
-    ////
-    //// EOF STUDENT CODE
-}
+//ChatBotPanelDialog::~ChatBotPanelDialog()
+//{
+//    //// STUDENT CODE
+//    ////
+//
+//    delete _chatLogic;
+//
+//    ////
+//    //// EOF STUDENT CODE
+//}
 
 void ChatBotPanelDialog::AddDialogItem(wxString text, bool isFromUser)
 {

--- a/src/chatgui.h
+++ b/src/chatgui.h
@@ -2,6 +2,7 @@
 #define CHATGUI_H_
 
 #include <wx/wx.h>
+#include <memory>
 
 class ChatLogic; // forward declaration
 

--- a/src/chatgui.h
+++ b/src/chatgui.h
@@ -15,8 +15,7 @@ private:
 
     //// STUDENT CODE
     ////
-
-    ChatLogic *_chatLogic;
+    std::unique_ptr<ChatLogic> _chatLogic;
 
     ////
     //// EOF STUDENT CODE


### PR DESCRIPTION
Updated the private member variable, `_chatLogic` in the `ChatBotPanelDialog` class to be a std::unique_ptr` instead of a raw pointer to force unique ownership rules.

This allowed for a cleaner construction without having to use `new` and also allowed us to use the default constructor instead of worrying about manually deallocating the memory in the heap where the variable lived.

**Other changes**
- Added `apt-get update` before the Python 3 PIP install in the Dockerfile since it was causing an error during the Docker build. See https://stackoverflow.com/questions/6587507/how-to-install-pip-with-python-3 for more info.