### PR TITLE
Add copy constructor to ChatBot class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_include_directories(membot PRIVATE ${wxWidgets_INCLUDE_DIRS})
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     message(STATUS "Configuring on/for macOS")
+    find_package(wxWidgets REQUIRED COMPONENTS core base)
+    include(${wxWidgets_USE_FILE})
+
     file(GLOB project_SRCS src/*.cpp)
 
     add_executable(membot ${project_SRCS})
+
+    target_link_libraries(membot ${wxWidgets_LIBRARIES})
 endif()
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get install -y build-essential && \
 RUN apt-get install -y git
 
 # clone develop repo
+RUN echo "Cloning develop branch"
 RUN git clone --single-branch --branch develop https://github.com/mharrisb1/memory-management-chatbot.git
 
 # workdir to be inside of the cloned repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get install -y build-essential && \
 RUN apt-get install -y git
 
 # clone develop repo
-RUN echo "Cloning develop branch"
 RUN git clone --single-branch --branch develop https://github.com/mharrisb1/memory-management-chatbot.git
 
 # workdir to be inside of the cloned repo

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -35,7 +35,7 @@ ChatBot::~ChatBot()
     std::cout << "ChatBot Destructor" << std::endl;
 
     // deallocate heap memory
-    if(_image != nullptr) // Attention: wxWidgets used NULL and not nullptr
+    if(_image != nullptr)
     {
         delete _image;
         _image = nullptr;
@@ -44,7 +44,19 @@ ChatBot::~ChatBot()
 
 //// STUDENT CODE
 ////
+// Copy constructor (deep copy)
+ChatBot::ChatBot(const ChatBot &source) {
 
+    // not owned
+    this->_rootNode = source._rootNode;
+    this->_chatLogic = source._chatLogic;
+    this->_chatLogic->SetChatbotHandle(this);  // not sure why this should be here
+
+    // owned
+    this->_image = new wxBitmap();
+    this->_image = *source._image;
+    std::cout << "ChatBot Copy Constructor" << std::endl;
+}
 ////
 //// EOF STUDENT CODE
 

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -15,7 +15,6 @@ ChatBot::ChatBot()
     _image = nullptr;
     _chatLogic = nullptr;
     _rootNode = nullptr;
-    std::cout << "ChatBot Constructor" << std::endl;
 }
 
 // constructor WITH memory allocation
@@ -26,7 +25,6 @@ ChatBot::ChatBot(std::string filename)
     // invalidate data handles
     _chatLogic = nullptr;
     _rootNode = nullptr;
-    std::cout << "ChatBot Constructor" << std::endl;
 
     // load image into heap memory
     _image = new wxBitmap(filename, wxBITMAP_TYPE_PNG);

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -54,7 +54,7 @@ ChatBot::ChatBot(const ChatBot &source) {
 
     // owned
     this->_image = new wxBitmap();
-    this->_image = *source._image;
+    *_image = *source._image;
     std::cout << "ChatBot Copy Constructor" << std::endl;
 }
 ////

--- a/src/chatbot.cpp
+++ b/src/chatbot.cpp
@@ -15,6 +15,7 @@ ChatBot::ChatBot()
     _image = nullptr;
     _chatLogic = nullptr;
     _rootNode = nullptr;
+    std::cout << "ChatBot Constructor" << std::endl;
 }
 
 // constructor WITH memory allocation
@@ -25,6 +26,7 @@ ChatBot::ChatBot(std::string filename)
     // invalidate data handles
     _chatLogic = nullptr;
     _rootNode = nullptr;
+    std::cout << "ChatBot Constructor" << std::endl;
 
     // load image into heap memory
     _image = new wxBitmap(filename, wxBITMAP_TYPE_PNG);

--- a/src/chatbot.h
+++ b/src/chatbot.h
@@ -30,6 +30,18 @@ public:
     //// STUDENT CODE
     ////
 
+    // copy constructor
+    ChatBot(const ChatBot &source);
+
+    // move constructor
+    ChatBot(const ChatBot &&source);
+
+    // copy assignment constructor
+    ChatBot &operator=(const ChatBot &source);
+
+    // move assignment constructor
+    ChatBot &operator=(const  ChatBot &&source);
+
     ////
     //// EOF STUDENT CODE
 

--- a/src/chatgui.cpp
+++ b/src/chatgui.cpp
@@ -130,16 +130,14 @@ ChatBotPanelDialog::ChatBotPanelDialog(wxWindow *parent, wxWindowID id)
     //// EOF STUDENT CODE
 }
 
-//ChatBotPanelDialog::~ChatBotPanelDialog()
-//{
-//    //// STUDENT CODE
-//    ////
-//
-//    delete _chatLogic;
-//
-//    ////
-//    //// EOF STUDENT CODE
-//}
+ChatBotPanelDialog::~ChatBotPanelDialog()
+{
+    //// STUDENT CODE
+    ////
+
+    ////
+    //// EOF STUDENT CODE
+}
 
 void ChatBotPanelDialog::AddDialogItem(wxString text, bool isFromUser)
 {


### PR DESCRIPTION
In one of the first steps in task 2, implement RAII "rule of five" to the `ChatBot` class, we added the copy constructor

**Additional changes**
- Fixed build error from the removal of the `ChatPanelDialog` destructor which threw an undefined symbol error during build.